### PR TITLE
ci: Use latest codecov action

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -38,4 +38,4 @@ jobs:
       run: make cover
 
     - name: Upload coverage
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v3


### PR DESCRIPTION
v1 has long been deprecated.